### PR TITLE
make THEN step for visibility ignore irrelevant invisible elements

### DIFF
--- a/addon-test-support/-private/steps/then.js
+++ b/addon-test-support/-private/steps/then.js
@@ -64,20 +64,18 @@ const steps = {
   },
 
   "Then (?:(\\d+) )?$opinionatedElement should (not |NOT )?be visible"(countRaw, [collection/* , label, selector */], no) {
-    assert(`Don't use NOT and number at the same time`, !(no && countRaw));
-
     let count =
-      no       ? 0                      :
       countRaw ? parseInt(countRaw, 10) :
                  1;
 
-    let m = `Element count`;
-    expect(collection, m).to.have.length(count);
-
-    collection.forEach((element, i) => {
-      m = `Element #${i} (zero-indexed) visibility`;
-      expect(isVisible(element), m).to.be.true;
-    });
+    const countVisible = collection.filter(element => isVisible(element)).length;
+    if (no) {
+      let m = `Invisible element count`;
+      expect(collection.length - countVisible, m).to.equal(count);
+    } else {
+      let m = `Visible element count`;
+      expect(countVisible, m).to.equal(count);
+    }
   },
 
   "Then I should see (NO |no )?(?:(\\d+) )?$opinionatedElement"(no, countRaw, [collection, label, selector]) {


### PR DESCRIPTION
when checking that COUNT elements are in/visible do not check the count of all found element but rather the count of those that are visible or invisible. This also allows to combine providing the COUNT with using the NOT option, e.g. `then 10 elements should not be visible`.